### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/src/ExternalSearch.Providers.AzureOpenAI/AzureOpenAIExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.AzureOpenAI/AzureOpenAIExternalSearchProvider.cs
@@ -578,9 +578,10 @@ public class AzureOpenAIExternalSearchProvider : ExternalSearchProviderBase, IEx
     private void PopulateMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<JObject> resultItem,
         IExternalSearchRequest request)
     {
+        var code = new EntityCode(request.EntityMetaData.EntityType, "AI", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
         metadata.EntityType = request.EntityMetaData.EntityType;
         metadata.Name = request.EntityMetaData.Name;
-        metadata.OriginEntityCode = request.EntityMetaData.OriginEntityCode;
+        metadata.OriginEntityCode = code;
 
         using var en = resultItem.Data.GetEnumerator();
         while (en.MoveNext())


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing Azure OpenAI data, but the one from other enricher turn into no source
![image](https://github.com/user-attachments/assets/255b3543-6b3e-4779-9cfc-579758725d3d)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
